### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/src/merge.js
+++ b/src/merge.js
@@ -98,6 +98,9 @@ Merge.objects = (target = {}, source, { arrayStrategy, ignore = [], parent = '' 
 
     // Return target if source and target are the same.
     if (value === target[key] || !_exists(value)) return
+    
+    // Skip merging if Prototype Pollution attempted
+    if (isPrototypePolluted(key)) return
 
     // If source is not iterable, overwrite the target.
     if (!_isIterable(value)) {
@@ -186,6 +189,15 @@ function _exists (value) {
  */
 function _isIterable (value) {
   return ['array', 'object'].includes(_trueType(value))
+}
+
+/**
+ * Blacklist certain keys to prevent Prototype Pollution
+ * @param {String} key
+ * @return {Boolean}
+ */
+function isPrototypePolluted(key) {
+  return ['__proto__', 'constructor', 'prototype'].includes(key)
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/src/merge.js
+++ b/src/merge.js
@@ -99,7 +99,7 @@ Merge.objects = (target = {}, source, { arrayStrategy, ignore = [], parent = '' 
     // Return target if source and target are the same.
     if (value === target[key] || !_exists(value)) return
     
-    // Skip merging if Prototype Pollution attempted
+    // Skip merging if attempting to pollute prototype
     if (isPrototypePolluted(key)) return
 
     // If source is not iterable, overwrite the target.
@@ -194,7 +194,7 @@ function _isIterable (value) {
 /**
  * Blacklist certain keys to prevent Prototype Pollution
  * @param {String} key
- * @return {Boolean}
+ * @return {Boolean} Whether key is blacklisted
  */
 function isPrototypePolluted(key) {
   return ['__proto__', 'constructor', 'prototype'].includes(key)

--- a/test/merge.spec.js
+++ b/test/merge.spec.js
@@ -81,6 +81,12 @@ describe('merge()', () => {
     expect(merge('', one, two)).toBe(two)
     expect(merge(one, two)).toBe(two)
   })
+
+  test('should not pollute prototype', () => {
+    let merged = merge({}, JSON.parse('{"__proto__": {"polluted": true}}'));
+    expect(merged).toEqual({})
+    expect({}.polluted).toBe(undefined)
+});
 })
 
 describe('merge({ arrayStrategy })', () => {


### PR DESCRIPTION
### :bar_chart: Metadata *

`@brikcss/merge` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40brikcss%2Fmerge

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```javascript
// poc.js
var merge = require("@brikcss/merge")
const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
var obj = {}
console.log("Before : " + {}.polluted);
merge(obj, payload);
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i @brikcss/merge # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/105152534-5739e500-5b2d-11eb-9c00-6a3058bf13ce.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
